### PR TITLE
Add a retrying rest proxy. I found this to be necessary for long-runn…

### DIFF
--- a/adam/__init__.py
+++ b/adam/__init__.py
@@ -17,5 +17,6 @@ from adam.service import Service
 from adam.rest_proxy import RestRequests
 from adam.rest_proxy import AuthenticatingRestProxy
 from adam.rest_proxy import LoggingRestProxy
+from adam.rest_proxy import RetryingRestProxy
 from adam.stm_propagation_module import StmPropagationModule
 from adam.stk import *

--- a/adam/tests/rest_proxy_test.py
+++ b/adam/tests/rest_proxy_test.py
@@ -1,7 +1,120 @@
 from adam import Auth
 from adam.rest_proxy import _RestProxyForTest
 from adam.rest_proxy import AuthenticatingRestProxy
+from adam.rest_proxy import RetryingRestProxy
 import unittest
+
+class RetryingRestProxyTest(unittest.TestCase):
+    """Unit tests for retrying rest proxy.
+    """
+
+    def test_good_response(self):
+        rest = _RestProxyForTest()
+        retrying_rest = RetryingRestProxy(rest)
+
+        expected_data = {}
+        def check_input(data_dict):
+            self.assertEqual(expected_data, data_dict)
+            return True
+            
+        # A 200 (or 204 for deletes) results in no retrying.
+        rest.expect_post("/test", check_input, 200, {'a': 1})
+        code, response = retrying_rest.post("/test", {})
+        self.assertEqual(200, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_get("/test?a=1&b=2", 200, {'a': 1})
+        code, response  = retrying_rest.get("/test?a=1&b=2")
+        self.assertEqual(200, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_delete("/test?a=1&b=2", 204)
+        code = retrying_rest.delete("/test?a=1&b=2")
+        self.assertEqual(204, code)
+    
+    def test_retry_on_retryable_error(self):
+        rest = _RestProxyForTest()
+        retrying_rest = RetryingRestProxy(rest)
+
+        expected_data = {}
+        def check_input(data_dict):
+            self.assertEqual(expected_data, data_dict)
+            return True
+            
+        # A 403, 502, or 503 results in retrying.
+        rest.expect_post("/test", check_input, 403, {'a': 1})
+        rest.expect_post("/test", check_input, 200, {'a': 1})
+        code, response = retrying_rest.post("/test", {})
+        self.assertEqual(200, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_get("/test?a=1&b=2", 502, {'a': 1})
+        rest.expect_get("/test?a=1&b=2", 200, {'a': 1})
+        code, response  = retrying_rest.get("/test?a=1&b=2")
+        self.assertEqual(200, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_delete("/test?a=1&b=2", 503)
+        rest.expect_delete("/test?a=1&b=2", 204)
+        code = retrying_rest.delete("/test?a=1&b=2")
+        self.assertEqual(204, code)
+    
+    def test_no_retry_on_nonretryable_error(self):
+        rest = _RestProxyForTest()
+        retrying_rest = RetryingRestProxy(rest)
+
+        expected_data = {}
+        def check_input(data_dict):
+            self.assertEqual(expected_data, data_dict)
+            return True
+            
+        # An error other than 403, 502, and 503 results in no retrying.
+        rest.expect_post("/test", check_input, 404, {'a': 1})
+        code, response = retrying_rest.post("/test", {})
+        self.assertEqual(404, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_get("/test?a=1&b=2", 418, {'a': 1})
+        code, response  = retrying_rest.get("/test?a=1&b=2")
+        self.assertEqual(418, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_delete("/test?a=1&b=2", 500)
+        code = retrying_rest.delete("/test?a=1&b=2")
+        self.assertEqual(500, code)
+
+    def test_eventually_stops_retrying(self):
+        rest = _RestProxyForTest()
+        retrying_rest = RetryingRestProxy(rest, num_tries=3)
+
+        expected_data = {}
+        def check_input(data_dict):
+            self.assertEqual(expected_data, data_dict)
+            return True
+            
+        # The retryable errors will eventually no longer be retried.
+        rest.expect_post("/test", check_input, 403, {'a': 1})
+        rest.expect_post("/test", check_input, 403, {'a': 1})
+        rest.expect_post("/test", check_input, 403, {'a': 1})
+        code, response = retrying_rest.post("/test", {})
+        self.assertEqual(403, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        rest.expect_get("/test?a=1&b=2", 502, {'a': 1})
+        rest.expect_get("/test?a=1&b=2", 502, {'a': 1})
+        rest.expect_get("/test?a=1&b=2", 502, {'a': 1})
+        code, response  = retrying_rest.get("/test?a=1&b=2")
+        self.assertEqual(502, code)
+        self.assertDictEqual({'a': 1}, response)
+
+        # Mixing errors is allowed - all count toward the same cumulative total. The error on the final
+        # try will be reported.
+        rest.expect_delete("/test?a=1&b=2", 403)
+        rest.expect_delete("/test?a=1&b=2", 502)
+        rest.expect_delete("/test?a=1&b=2", 503)
+        code = retrying_rest.delete("/test?a=1&b=2")
+        self.assertEqual(503, code)
+
 
 class AuthenticatingRestProxyTest(unittest.TestCase):
     """Unit tests for authenticating rest proxy.
@@ -65,3 +178,6 @@ class AuthenticatingRestProxyTest(unittest.TestCase):
         
         rest.expect_delete("/test?a=1&b=2&token=my_token", 200)
         auth_rest.delete("/test?a=1&b=2")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…ing things, since we get some sporadic errors. It doesn't do anything about the persistent session issues that we were encountering with the notebooks, but should help with things like transient 502s, which we occasionally get when app engine is a bit overloaded