### PR TITLE
Support keplerian elements in client

### DIFF
--- a/adam/batch.py
+++ b/adam/batch.py
@@ -122,14 +122,13 @@ class OpmParams(object):
                 of the object.
             keplerian_elements (dictionary): contains 7 elements representing the
                 keplerian coordinates of the object. The elements are:
-                    semi_major_axis_km: semi_major_axis (float): Semimajor axis (km)
-                    eccentricity: eccentricity (float): Eccentricity of orbit
-                    inclination_deg: inclination (float): Inclination of orbit (deg)
-                    ra_of_asc_node_deg: ra_of_asc_node (float): Right ascension of ascending node
-                                                                (deg)
-                    arg_of_pericenter_deg: arg_of_pericenter (float): Argument of pericenter (deg)
-                    true_anomaly_deg: true_anomaly (float): True anomaly (deg)
-                    gm: gm (float): Gravitational constant (km^3/s^2)
+                    semi_major_axis_km (float): Semimajor axis (km)
+                    eccentricity (float): Eccentricity of orbit
+                    inclination_deg (float): Inclination of orbit (deg)
+                    ra_of_asc_node_deg (float): Right ascension of ascending node (deg)
+                    arg_of_pericenter_deg (float): Argument of pericenter (deg)
+                    true_anomaly_deg (float): True anomaly (deg)
+                    gm (float): Gravitational constant (km^3/s^2)
 
             originator (str): responsible entity for run (default: 'ADAM_User')
             object_name (str): name of object (default: 'dummy')

--- a/adam/batch.py
+++ b/adam/batch.py
@@ -110,14 +110,14 @@ class OpmParams(object):
     def __init__(self, params):
         """
         Param options are:
-            
+
             --- epoch is required! ---
             epoch (str): the epoch associated with the state vector (IS0-8601 format)
 
             --- either state_vector or keplerian_elements is required! ---
-            --- note that if keplerian_elements are provided, state_vector will be ignored 
+            --- note that if keplerian_elements are provided, state_vector will be ignored
             --- by server side even if also provided. ---
-            state_vector (list): an array with 6 elements [rx, ry, rz, vx, vy, vz] 
+            state_vector (list): an array with 6 elements [rx, ry, rz, vx, vy, vz]
                 representing the cartesian coordinates (the position and velocity vector)
                 of the object.
             keplerian_elements (list): an array with 7 elements representing the
@@ -129,7 +129,7 @@ class OpmParams(object):
                     4: arg_of_pericenter (float): Argument of pericenter (deg)
                     5: true_anomaly (float): True anomaly (deg)
                     6: gm (float): Gravitational constant (km^3/s^2)
-        
+
             originator (str): responsible entity for run (default: 'ADAM_User')
             object_name (str): name of object (default: 'dummy')
             object_id (str): identification of object (default: '001')
@@ -154,7 +154,10 @@ class OpmParams(object):
         """
         # Make this a bit easier to get right by checking for parameters by unexpected
         # names.
-        supported_params = {'epoch', 'state_vector', 'keplerian_elements', 'originator', 'object_name', 'object_id', 'mass', 'solar_rad_area', 'solar_rad_coeff', 'drag_area', 'drag_coeff', 'covariance', 'perturbation', 'hypercube'}
+        supported_params = {'epoch', 'state_vector', 'keplerian_elements', 'originator',
+                            'object_name', 'object_id', 'mass', 'solar_rad_area',
+                            'solar_rad_coeff', 'drag_area', 'drag_coeff', 'covariance',
+                            'perturbation', 'hypercube'}
         extra_params = params.keys() - supported_params
         if len(extra_params) > 0:
             raise KeyError("Unexpected parameters provided: %s" % (extra_params))
@@ -165,7 +168,7 @@ class OpmParams(object):
             raise KeyError("Either state_vector or keplerian_elements must be provided.")
         self._state_vector = params.get('state_vector') or [0, 0, 0, 0, 0, 0]  # Required in OPM.
         self._keplerian_elements = params.get('keplerian_elements')
-        
+
         self._originator = params.get('originator') or 'ADAM_User'
         self._object_name = params.get('object_name') or 'dummy'
         self._object_id = params.get('object_id') or '001'
@@ -200,23 +203,23 @@ class OpmParams(object):
         Returns:
             OPM (str)
         """
-        base_opm =  "CCSDS_OPM_VERS = 2.0\n" + \
-                    ("CREATION_DATE = %s\n" % datetime.utcnow()) + \
-                    ("ORIGINATOR = %s\n" % self._originator) + \
-                    "COMMENT Cartesian coordinate system\n" + \
-                    ("OBJECT_NAME = %s\n" % self._object_name) + \
-                    ("OBJECT_ID = %s\n" % self._object_id) + \
-                    "CENTER_NAME = SUN\n" + \
-                    "REF_FRAME = ITRF-97\n" + \
-                    "TIME_SYSTEM = UTC\n" + \
-                    ("EPOCH = %s\n" % self._epoch) + \
-                    ("X = %s\n" % (self._state_vector[0])) + \
-                    ("Y = %s\n" % (self._state_vector[1])) + \
-                    ("Z = %s\n" % (self._state_vector[2])) + \
-                    ("X_DOT = %s\n" % (self._state_vector[3])) + \
-                    ("Y_DOT = %s\n" % (self._state_vector[4])) + \
-                    ("Z_DOT = %s\n" % (self._state_vector[5]))
-        
+        base_opm = "CCSDS_OPM_VERS = 2.0\n" + \
+            ("CREATION_DATE = %s\n" % datetime.utcnow()) + \
+            ("ORIGINATOR = %s\n" % self._originator) + \
+            "COMMENT Cartesian coordinate system\n" + \
+            ("OBJECT_NAME = %s\n" % self._object_name) + \
+            ("OBJECT_ID = %s\n" % self._object_id) + \
+            "CENTER_NAME = SUN\n" + \
+            "REF_FRAME = ITRF-97\n" + \
+            "TIME_SYSTEM = UTC\n" + \
+            ("EPOCH = %s\n" % self._epoch) + \
+            ("X = %s\n" % (self._state_vector[0])) + \
+            ("Y = %s\n" % (self._state_vector[1])) + \
+            ("Z = %s\n" % (self._state_vector[2])) + \
+            ("X_DOT = %s\n" % (self._state_vector[3])) + \
+            ("Y_DOT = %s\n" % (self._state_vector[4])) + \
+            ("Z_DOT = %s\n" % (self._state_vector[5]))
+
         keplerian_elements = ""
         if self._keplerian_elements is not None:
             keplerian_elements = \
@@ -263,7 +266,8 @@ class OpmParams(object):
                          ("USER_DEFINED_ADAM_HYPERCUBE = %s\n" % self._hypercube)
 
         return base_opm + keplerian_elements + spacecraft_params + covariance
-        
+
+
 class StateSummary(object):
     def __init__(self, json):
         """ Requires a json response as returned from the server representing a batch

--- a/adam/stm_propagation_module.py
+++ b/adam/stm_propagation_module.py
@@ -122,7 +122,7 @@ class StmPropagationModule(object):
                     Propagation-related parameters for the STM propagations
                 opm_params (OpmParams):
                     OPM-related parameters for the propagations, including the nominal
-                    state vector that will be varied.
+                    state vector that will be varied. Keplerian elements not supported.
 
             Returns:
                 end_state (list):
@@ -131,6 +131,9 @@ class StmPropagationModule(object):
                 stm (matrix):
                     STM describing effect of changes to initial state on final state
         """
+        if opm_params.get_state_vector() is None:
+            raise KeyError('Only coordinates specified via a state vector are supported.')
+
         end_state, stm = self._evaluate_func_with_derivative(
             opm_params.get_state_vector(),
             self._propagate_states,

--- a/adam/tests/batch_test.py
+++ b/adam/tests/batch_test.py
@@ -200,7 +200,7 @@ DRAG_COEFF = 2.2"""
 
         with self.assertRaises(KeyError):
             OpmParams({'keplerian_elements': []})
-        
+
         # No KeyError with no state vector.
         OpmParams({'epoch': 'foo', 'keplerian_elements': []})
 

--- a/adam/tests/batch_test.py
+++ b/adam/tests/batch_test.py
@@ -84,7 +84,15 @@ class OpmParamsTest(unittest.TestCase):
         o = OpmParams({
             'epoch': 'foo',
             'state_vector': [1, 2, 3, 4, 5, 6],
-            'keplerian_elements': [1, 2, 3, 4, 5, 6, 7],
+            'keplerian_elements': {
+                'semi_major_axis_km': 1,
+                'eccentricity': 2,
+                'inclination_deg': 3,
+                'ra_of_asc_node_deg': 4,
+                'arg_of_pericenter_deg': 5,
+                'true_anomaly_deg': 6,
+                'gm': 7
+            },
 
             'originator': 'a',
             'object_name': 'b',
@@ -199,10 +207,56 @@ DRAG_COEFF = 2.2"""
             OpmParams({'state_vector': []})
 
         with self.assertRaises(KeyError):
-            OpmParams({'keplerian_elements': []})
+            OpmParams({
+                'keplerian_elements': {
+                    'semi_major_axis_km': 1,
+                    'eccentricity': 2,
+                    'inclination_deg': 3,
+                    'ra_of_asc_node_deg': 4,
+                    'arg_of_pericenter_deg': 5,
+                    'true_anomaly_deg': 6,
+                    'gm': 7
+                }})
+
+        with self.assertRaises(KeyError):
+            OpmParams({
+                'epoch': 'foo',
+                'keplerian_elements': {
+                    'semi_major_axis_km': 1,
+                    'eccentricity': 2,
+                    'inclination_deg': 3,
+                    'ra_of_asc_node_deg': 4,
+                    'arg_of_pericenter_deg': 5,
+                    'true_anomaly_deg': 6,
+                    # Missing gm.
+                }})
+
+        with self.assertRaises(KeyError):
+            OpmParams({
+                'epoch': 'foo',
+                'keplerian_elements': {
+                    'semi_major_axis_km': 1,
+                    'eccentricity': 2,
+                    'inclination_deg': 3,
+                    'ra_of_asc_node_deg': 4,
+                    'arg_of_pericenter_deg': 5,
+                    'true_anomaly_deg': 6,
+                    'gm': 7,
+                    'extra what is this': 8
+                }})
 
         # No KeyError with no state vector.
-        OpmParams({'epoch': 'foo', 'keplerian_elements': []})
+        OpmParams({
+            'epoch': 'foo',
+            'keplerian_elements': {
+                'semi_major_axis_km': 1,
+                'eccentricity': 2,
+                'inclination_deg': 3,
+                'ra_of_asc_node_deg': 4,
+                'arg_of_pericenter_deg': 5,
+                'true_anomaly_deg': 6,
+                'gm': 7
+            }})
 
     def test_invalid_keys(self):
         with self.assertRaises(KeyError):

--- a/adam/tests/batch_test.py
+++ b/adam/tests/batch_test.py
@@ -81,6 +81,7 @@ class OpmParamsTest(unittest.TestCase):
         o = OpmParams({
             'epoch': 'foo',
             'state_vector': [1, 2, 3, 4, 5, 6],
+            'keplerian_elements': [1, 2, 3, 4, 5, 6, 7],
 
             'originator': 'a',
             'object_name': 'b',
@@ -111,6 +112,13 @@ Z = 3
 X_DOT = 4
 Y_DOT = 5
 Z_DOT = 6
+SEMI_MAJOR_AXIS = 1
+ECCENTRICITY = 2
+INCLINATION = 3
+RA_OF_ASC_NODE = 4
+ARG_OF_PERICENTER = 5
+TRUE_ANOMALY = 6
+GM = 7
 MASS = 1
 SOLAR_RAD_AREA = 2
 SOLAR_RAD_COEFF = 3
@@ -185,6 +193,12 @@ DRAG_COEFF = 2.2"""
 
         with self.assertRaises(KeyError):
             OpmParams({'state_vector': []})
+
+        with self.assertRaises(KeyError):
+            OpmParams({'keplerian_elements': []})
+        
+        # No KeyError with no state vector.
+        OpmParams({'epoch': 'foo', 'keplerian_elements': []})
 
     def test_invalid_keys(self):
         with self.assertRaises(KeyError):

--- a/adam/tests/integration_tests/backwards_propagation_test.py
+++ b/adam/tests/integration_tests/backwards_propagation_test.py
@@ -13,8 +13,8 @@ import os
 import numpy as np
 import numpy.testing as npt
 
-class BatchRunnerTest(unittest.TestCase):
-    """Integration test of batch running.
+class BackwardsPropagationTest(unittest.TestCase):
+    """Integration test of backwards propagation.
     
     """
     def setUp(self):

--- a/adam/tests/integration_tests/backwards_propagation_test.py
+++ b/adam/tests/integration_tests/backwards_propagation_test.py
@@ -12,9 +12,10 @@ import os
 import numpy as np
 import numpy.testing as npt
 
+
 class BackwardsPropagationTest(unittest.TestCase):
     """Integration test of backwards propagation.
-    
+
     """
 
     def setUp(self):

--- a/adam/tests/integration_tests/keplerian_test.py
+++ b/adam/tests/integration_tests/keplerian_test.py
@@ -1,0 +1,98 @@
+from adam import Service
+from adam import Batch
+from adam import PropagationParams
+from adam import OpmParams
+from adam import BatchRunManager
+from adam import ConfigManager
+
+import json
+import unittest
+import datetime
+import os
+
+import numpy as np
+import numpy.testing as npt
+
+class KeplerianTest(unittest.TestCase):
+    """Integration test of using keplerian elements instead of cartesian.
+    
+    """
+    def setUp(self):
+        config = ConfigManager(os.getcwd() + '/test_config.json').get_config()
+        self.service = Service(config)
+        self.assertTrue(self.service.setup())
+        self.working_project = self.service.new_working_project()
+        self.assertIsNotNone(self.working_project)
+
+    def tearDown(self):
+        self.service.teardown()
+        
+    def make_cartesian_and_keplerian_batches(self, start_time_str, end_time_str):
+        # These are equivalent cartesian and keplerian elements.
+        keplerian_elements = [
+            3.1307289138037175E8,  # Semimajor axis (km)
+            0.5355029800000188,  # Eccentricity
+            0.4090995347727893,  # Inclination (deg)
+            5.7344265189168055,  # Right ascension of ascending node (deg)
+            6.2830852879040275,  # Argument of pericenter (aka periapsis) (deg)
+            -2.216878629258714,  # True anomaly (deg)
+            1.327124400419394E11  # Gravitational constant, this one for the sun (km^3/s^2)
+        ]
+
+        cartesian_state_vector = [
+            -3.065363415010223E11, -1.1097955684640254E11, -4.812970642252724E10,  # x, y, z
+            15759.855276409047, -10587.56732919585, -4589.673432886973  # dx, dy, dZ
+        ]
+        
+        propagation_params = PropagationParams({
+            'start_time': start_time_str,
+            'end_time': end_time_str,
+            'step_size': 0,
+            'project_uuid': self.working_project.get_uuid(),
+            'description': 'Created by test at ' + start_time_str
+        })
+        opm_params_templ = {
+            'epoch': start_time_str,
+            'keplerian_elements': keplerian_elements,
+            
+            'mass': 500.5,
+            'solar_rad_area': 25.2,
+            'solar_rad_coeff': 1.2,
+            'drag_area': 33.3,
+            'drag_coeff': 2.5,
+            
+            'originator': 'Test',
+            'object_name': 'TestObj',
+            'object_id': 'TestObjId',
+        }
+
+        cartesian_opm_params = opm_params_templ.copy()
+        cartesian_opm_params['state_vector'] = cartesian_state_vector
+
+        keplerian_opm_params = opm_params_templ.copy()
+        keplerian_opm_params['keplerian_elements'] = keplerian_elements
+        
+        cartesian = Batch(propagation_params, OpmParams(cartesian_opm_params))
+        keplerian = Batch(propagation_params, OpmParams(keplerian_opm_params))
+        return cartesian, keplerian
+        
+    def test_keplerian_and_cartesian(self):
+        start = datetime.datetime.now()
+        end = start + datetime.timedelta(10 * 365)  # 10 years
+        start_time_str = start.isoformat() + 'Z'
+        end_time_str = end.isoformat() + 'Z'
+
+        cartesian, keplerian = self.make_cartesian_and_keplerian_batches(start_time_str, end_time_str)
+    
+        BatchRunManager(self.service.get_batches_module(), [cartesian, keplerian]).run()
+
+        cartesian_end_state = cartesian.get_results().get_end_state_vector()
+        keplerian_end_state = keplerian.get_results().get_end_state_vector()
+
+        difference = np.subtract(cartesian_end_state, keplerian_end_state)
+        npt.assert_allclose(difference[0:3], [0, 0, 0], rtol=0, atol=1e-3)
+        npt.assert_allclose(difference[3:6], [0, 0, 0], rtol=0, atol=1e-10)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/adam/tests/integration_tests/keplerian_test.py
+++ b/adam/tests/integration_tests/keplerian_test.py
@@ -5,7 +5,6 @@ from adam import OpmParams
 from adam import BatchRunManager
 from adam import ConfigManager
 
-import json
 import unittest
 import datetime
 import os
@@ -13,10 +12,12 @@ import os
 import numpy as np
 import numpy.testing as npt
 
+
 class KeplerianTest(unittest.TestCase):
     """Integration test of using keplerian elements instead of cartesian.
-    
+
     """
+
     def setUp(self):
         config = ConfigManager(os.getcwd() + '/test_config.json').get_config()
         self.service = Service(config)
@@ -26,44 +27,39 @@ class KeplerianTest(unittest.TestCase):
 
     def tearDown(self):
         self.service.teardown()
-        
+
     def make_cartesian_and_keplerian_batches(self, start_time_str, end_time_str):
         # These are equivalent cartesian and keplerian elements.
         keplerian_elements = [
             3.1307289138037175E8,  # Semimajor axis (km)
             0.5355029800000188,  # Eccentricity
-            0.4090995347727893,  # Inclination (deg)
-            5.7344265189168055,  # Right ascension of ascending node (deg)
-            6.2830852879040275,  # Argument of pericenter (aka periapsis) (deg)
-            -2.216878629258714,  # True anomaly (deg)
+            23.439676743246295,  # Inclination (deg)
+            359.9942693176405,  # Right ascension of ascending node (deg)
+            328.5584374618295,  # Argument of pericenter (aka periapsis) (deg)
+            -127.01778914927144,  # True anomaly (deg)
             1.327124400419394E11  # Gravitational constant, this one for the sun (km^3/s^2)
         ]
-
-        cartesian_state_vector = [
-            -3.065363415010223E11, -1.1097955684640254E11, -4.812970642252724E10,  # x, y, z
-            15759.855276409047, -10587.56732919585, -4589.673432886973  # dx, dy, dZ
-        ]
         
+        cartesian_state_vector = [
+            -3.0653634150102222e8, -1.1097955684640282e8, -4.8129706422527283e7,  # x, y, z
+            15.7598552764090590, -10.5875673291958420, -4.5896734328869746  # dx, dy, dZ
+        ]
+
         propagation_params = PropagationParams({
             'start_time': start_time_str,
             'end_time': end_time_str,
-            'step_size': 0,
             'project_uuid': self.working_project.get_uuid(),
             'description': 'Created by test at ' + start_time_str
         })
         opm_params_templ = {
             'epoch': start_time_str,
-            'keplerian_elements': keplerian_elements,
-            
+            # state_vector or keplerian_elements will be set later.
+
             'mass': 500.5,
             'solar_rad_area': 25.2,
             'solar_rad_coeff': 1.2,
             'drag_area': 33.3,
-            'drag_coeff': 2.5,
-            
-            'originator': 'Test',
-            'object_name': 'TestObj',
-            'object_id': 'TestObjId',
+            'drag_coeff': 2.5
         }
 
         cartesian_opm_params = opm_params_templ.copy()
@@ -71,28 +67,29 @@ class KeplerianTest(unittest.TestCase):
 
         keplerian_opm_params = opm_params_templ.copy()
         keplerian_opm_params['keplerian_elements'] = keplerian_elements
-        
+
         cartesian = Batch(propagation_params, OpmParams(cartesian_opm_params))
         keplerian = Batch(propagation_params, OpmParams(keplerian_opm_params))
         return cartesian, keplerian
-        
+
     def test_keplerian_and_cartesian(self):
         start = datetime.datetime.now()
-        end = start + datetime.timedelta(10 * 365)  # 10 years
+        end = start + datetime.timedelta(10)  # 10 days
         start_time_str = start.isoformat() + 'Z'
         end_time_str = end.isoformat() + 'Z'
 
-        cartesian, keplerian = self.make_cartesian_and_keplerian_batches(start_time_str, end_time_str)
-    
+        cartesian, keplerian = self.make_cartesian_and_keplerian_batches(
+            start_time_str, end_time_str)
+
         BatchRunManager(self.service.get_batches_module(), [cartesian, keplerian]).run()
 
         cartesian_end_state = cartesian.get_results().get_end_state_vector()
         keplerian_end_state = keplerian.get_results().get_end_state_vector()
 
         difference = np.subtract(cartesian_end_state, keplerian_end_state)
-        npt.assert_allclose(difference[0:3], [0, 0, 0], rtol=0, atol=1e-3)
+        npt.assert_allclose(difference[0:3], [0, 0, 0], rtol=0, atol=1e-5)
         npt.assert_allclose(difference[3:6], [0, 0, 0], rtol=0, atol=1e-10)
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/adam/tests/integration_tests/keplerian_test.py
+++ b/adam/tests/integration_tests/keplerian_test.py
@@ -29,16 +29,15 @@ class KeplerianTest(unittest.TestCase):
         self.service.teardown()
 
     def make_cartesian_and_keplerian_batches(self, start_time_str, end_time_str):
-        # These are equivalent cartesian and keplerian elements.
-        keplerian_elements = [
-            3.1307289138037175E8,  # Semimajor axis (km)
-            0.5355029800000188,  # Eccentricity
-            23.439676743246295,  # Inclination (deg)
-            359.9942693176405,  # Right ascension of ascending node (deg)
-            328.5584374618295,  # Argument of pericenter (aka periapsis) (deg)
-            -127.01778914927144,  # True anomaly (deg)
-            1.327124400419394E11  # Gravitational constant, this one for the sun (km^3/s^2)
-        ]
+        keplerian_elements = {
+            'semi_major_axis_km': 3.1307289138037175E8,
+            'eccentricity': 0.5355029800000188,
+            'inclination_deg': 23.439676743246295,
+            'ra_of_asc_node_deg': 359.9942693176405,
+            'arg_of_pericenter_deg': 328.5584374618295,
+            'true_anomaly_deg': -127.01778914927144,
+            'gm': 1.327124400419394E11
+        }
 
         cartesian_state_vector = [
             -3.0653634150102222e8, -1.1097955684640282e8, -4.8129706422527283e7,  # x, y, z

--- a/adam/tests/integration_tests/keplerian_test.py
+++ b/adam/tests/integration_tests/keplerian_test.py
@@ -39,7 +39,7 @@ class KeplerianTest(unittest.TestCase):
             -127.01778914927144,  # True anomaly (deg)
             1.327124400419394E11  # Gravitational constant, this one for the sun (km^3/s^2)
         ]
-        
+
         cartesian_state_vector = [
             -3.0653634150102222e8, -1.1097955684640282e8, -4.8129706422527283e7,  # x, y, z
             15.7598552764090590, -10.5875673291958420, -4.5896734328869746  # dx, dy, dZ


### PR DESCRIPTION
See if you like how this is supported. Basically OpmParams now allows specifying either 'state_vector': [...] or 'keplerian_elements': [...]. I made keplerian_elements an array to make it state-vector-like, but it may be better to make it a nested object with named fields, or to just have all the keplerian elements as top-level named fields. For now, I figure everyone who actually wants to do this will just be copy-pasting examples so it doesn't matter anyway.