### PR TITLE
Add a notebook that can be used to generate workspace projects for a new user. 

### DIFF
--- a/demos/create_workspace.ipynb
+++ b/demos/create_workspace.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### This notebook sets up workspaces for a new user. Can only be run by someone with sufficient access."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from adam import ConfigManager\n",
+    "from adam import Service\n",
+    "from adam import Permission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Edit this to reflect the user and parent workspace for which you would like to add a workspace.\n",
+    "\n",
+    "Note: it's unusual for dev and prod to have the same uuids for anything - they happen to have the same uuids for a few objects created early on in the life of ADAM because at one point we copied the table contents. For newly created objects uuids will be assigned independently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = \"Elliot Huebler\"\n",
+    "email = \"elliothuebler@gmail.com\"\n",
+    "description = \"Workspace for \" + name + \" within Asteroid Institute\"\n",
+    "parent_project_prod = \"74020cfb-6528-4fb8-b170-5e7b2b0dc737\"  # The Asteroid Institute shared parent project.\n",
+    "parent_project_dev = \"74020cfb-6528-4fb8-b170-5e7b2b0dc737\"  # The Asteroid Institute shared parent project.\n",
+    "team_group_prod = \"ae62ec66-836c-4c4c-8e25-c643ec46b58c\"  # The Asteroid Institute team group.\n",
+    "team_group_dev = \"ae62ec66-836c-4c4c-8e25-c643ec46b58c\"  # The Asteroid Institute team group."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This sets up a workspace in prod for the given user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting up project and group membership for Elliot Huebler in prod.\n",
+      "[0.363484] Setup\n",
+      "Found existing project for Elliot Huebler with uuid bea0e10d-2868-4adf-b9ec-09dc9983c1f7\n",
+      "elliothuebler@gmail.com is already a member of group ae62ec66-836c-4c4c-8e25-c643ec46b58c\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Setting up project and group membership for \" + name + \" in prod.\")\n",
+    "\n",
+    "config = ConfigManager(os.getcwd() + '/config.json').get_config('prod')\n",
+    "service = Service(config)\n",
+    "service.setup()\n",
+    "\n",
+    "# Adds the new project if there isn't one.\n",
+    "projects = service.get_projects_module()\n",
+    "project = None\n",
+    "for p in projects.get_sub_projects(parent_project_prod):\n",
+    "    if p.get_name() == name:\n",
+    "        project = p\n",
+    "        print(\"Found existing workspace for \" + name + \" with uuid \" + p.get_uuid())\n",
+    "if project is None:\n",
+    "    project = projects.new_project(parent_project_prod, name, description)\n",
+    "    print(\"Created workspace for \" + name + \" with uuid \" + project.get_uuid())\n",
+    "\n",
+    "    # Gives permission to the new project.\n",
+    "    permissions = service.get_permissions_module()\n",
+    "    permissions.grant_user_permission(email, Permission('ADMIN', 'PROJECT', project.get_uuid()))\n",
+    "    print(\"Granted admin permission to \" + email + \" on project \" + project.get_uuid())\n",
+    "\n",
+    "# Adds user to team group, if they're not already in it.\n",
+    "if team_group_prod is not None:\n",
+    "    groups = service.get_groups_module()\n",
+    "    if not email in [g.get_id() for g in groups.get_group_members(team_group_prod) if g.get_type() == \"USER\"]:\n",
+    "        groups.add_user_to_group(email, team_group_prod)\n",
+    "        print(\"Added \" + email + \" to group \" + team_group_prod)\n",
+    "    else:\n",
+    "        print(email + \" is already a member of group \" + team_group_prod)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This sets up a workspace in dev for the given user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting up project and group membership for Elliot Huebler in dev.\n",
+      "[0.424105] Setup\n",
+      "Created workspace for Elliot Huebler with uuid d4eb999d-360a-4206-8745-8d06021e7313\n",
+      "Granted admin permission to elliothuebler@gmail.com on project d4eb999d-360a-4206-8745-8d06021e7313\n",
+      "Added elliothuebler@gmail.com to group ae62ec66-836c-4c4c-8e25-c643ec46b58c\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Setting up project and group membership for \" + name + \" in dev.\")\n",
+    "\n",
+    "config = ConfigManager(os.getcwd() + '/config.json').get_config('dev')\n",
+    "service = Service(config)\n",
+    "service.setup()\n",
+    "\n",
+    "# Adds the new project if there isn't one.\n",
+    "projects = service.get_projects_module()\n",
+    "project = None\n",
+    "for p in projects.get_sub_projects(parent_project_dev):\n",
+    "    if p.get_name() == name:\n",
+    "        project = p\n",
+    "        print(\"Found existing workspace for \" + name + \" with uuid \" + p.get_uuid())\n",
+    "if project is None:\n",
+    "    project = projects.new_project(parent_project_dev, name, description)\n",
+    "    print(\"Created workspace for \" + name + \" with uuid \" + project.get_uuid())\n",
+    "\n",
+    "    # Gives permission to the new project.\n",
+    "    permissions = service.get_permissions_module()\n",
+    "    permissions.grant_user_permission(email, Permission('ADMIN', 'PROJECT', project.get_uuid()))\n",
+    "    print(\"Granted admin permission to \" + email + \" on project \" + project.get_uuid())\n",
+    "\n",
+    "# Adds user to team group, if they're not already in it.\n",
+    "if team_group_dev is not None:\n",
+    "    groups = service.get_groups_module()\n",
+    "    if not email in [g.get_id() for g in groups.get_group_members(team_group_dev) if g.get_type() == \"USER\"]:\n",
+    "        groups.add_user_to_group(email, team_group_dev)\n",
+    "        print(\"Added \" + email + \" to group \" + team_group_dev)\n",
+    "    else:\n",
+    "        print(email + \" is already a member of group \" + team_group_dev)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/demos/create_workspace.ipynb
+++ b/demos/create_workspace.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,12 +29,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"Elliot Huebler\"\n",
-    "email = \"elliothuebler@gmail.com\"\n",
+    "name = # Fill this in!\n",
+    "email = # Fill this in!\n",
     "description = \"Workspace for \" + name + \" within Asteroid Institute\"\n",
     "parent_project_prod = \"74020cfb-6528-4fb8-b170-5e7b2b0dc737\"  # The Asteroid Institute shared parent project.\n",
     "parent_project_dev = \"74020cfb-6528-4fb8-b170-5e7b2b0dc737\"  # The Asteroid Institute shared parent project.\n",
@@ -51,20 +51,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Setting up project and group membership for Elliot Huebler in prod.\n",
-      "[0.363484] Setup\n",
-      "Found existing project for Elliot Huebler with uuid bea0e10d-2868-4adf-b9ec-09dc9983c1f7\n",
-      "elliothuebler@gmail.com is already a member of group ae62ec66-836c-4c4c-8e25-c643ec46b58c\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Setting up project and group membership for \" + name + \" in prod.\")\n",
     "\n",
@@ -107,21 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Setting up project and group membership for Elliot Huebler in dev.\n",
-      "[0.424105] Setup\n",
-      "Created workspace for Elliot Huebler with uuid d4eb999d-360a-4206-8745-8d06021e7313\n",
-      "Granted admin permission to elliothuebler@gmail.com on project d4eb999d-360a-4206-8745-8d06021e7313\n",
-      "Added elliothuebler@gmail.com to group ae62ec66-836c-4c4c-8e25-c643ec46b58c\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Setting up project and group membership for \" + name + \" in dev.\")\n",
     "\n",

--- a/demos/create_workspace.ipynb
+++ b/demos/create_workspace.ipynb
@@ -15,7 +15,8 @@
    "source": [
     "from adam import ConfigManager\n",
     "from adam import Service\n",
-    "from adam import Permission"
+    "from adam import Permission\n",
+    "import os"
    ]
   },
   {
@@ -33,8 +34,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = # Fill this in!\n",
-    "email = # Fill this in!\n",
+    "name = \"\" # Fill this in! Can be any string - used in descriptions, etc. Example: Laura Lark\n",
+    "email = \"\" # Fill this in! Needs to exactly match the email the user will be logging in with. Example: laurahlark@gmail.com\n",
+    "\n",
+    "# Note! These are all currently filled out for the Asteroid Institute team. Alter if you are adding somebody\n",
+    "# to a different team's groups, e.g. UW's DIRAC group.\n",
     "description = \"Workspace for \" + name + \" within Asteroid Institute\"\n",
     "parent_project_prod = \"74020cfb-6528-4fb8-b170-5e7b2b0dc737\"  # The Asteroid Institute shared parent project.\n",
     "parent_project_dev = \"74020cfb-6528-4fb8-b170-5e7b2b0dc737\"  # The Asteroid Institute shared parent project.\n",
@@ -84,7 +88,9 @@
     "        groups.add_user_to_group(email, team_group_prod)\n",
     "        print(\"Added \" + email + \" to group \" + team_group_prod)\n",
     "    else:\n",
-    "        print(email + \" is already a member of group \" + team_group_prod)"
+    "        print(email + \" is already a member of group \" + team_group_prod)\n",
+    "\n",
+    "service.teardown()"
    ]
   },
   {
@@ -129,7 +135,9 @@
     "        groups.add_user_to_group(email, team_group_dev)\n",
     "        print(\"Added \" + email + \" to group \" + team_group_dev)\n",
     "    else:\n",
-    "        print(email + \" is already a member of group \" + team_group_dev)"
+    "        print(email + \" is already a member of group \" + team_group_dev)\n",
+    "\n",
+    "service.teardown()"
    ]
   },
   {


### PR DESCRIPTION
Note: can only be run by someone with the proper permissions on the parent workspace projects.