### PR TITLE
Support a public project in dev. This should fix the test failure whe…

### DIFF
--- a/adam/batch.py
+++ b/adam/batch.py
@@ -77,7 +77,8 @@ class PropagationParams(object):
 
         self._start_time = params['start_time']  # Required.
         self._end_time = params['end_time']  # Required.
-        self._step_size = params.get('step_size') or 86400
+        # Check explicitly for None, since 0 is a valid value.
+        self._step_size = params.get('step_size') if params.get('step_size') is not None else 86400
         self._propagator_uuid = params.get('propagator_uuid') or self.DEFAULT_CONFIG_ID
         self._project_uuid = params.get('project_uuid')
         self._description = params.get('description')

--- a/adam/tests/integration_tests/anonymous_test.py
+++ b/adam/tests/integration_tests/anonymous_test.py
@@ -28,14 +28,9 @@ class AnonymousTest(unittest.TestCase):
         permissions_module = self.service.get_permissions_module()
         groups_module = self.service.get_groups_module()
 
-        # Only prod has a public project.
         projects = projects_module.get_projects()
-        if self.config.get_environment() == "prod":
-            self.assertEqual(1, len(projects))
-            self.assertEqual("public", projects[0].get_name())
-        else:
-            self.assertEqual(0, len(projects))
-            print("Skipping check for public objects.")
+        self.assertEqual(1, len(projects))
+        self.assertEqual("public", projects[0].get_name())
 
         # Can't add a project to public project.
         public_project = "00000000-0000-0000-0000-000000000001"

--- a/adam/tests/integration_tests/backwards_propagation_test.py
+++ b/adam/tests/integration_tests/backwards_propagation_test.py
@@ -35,7 +35,7 @@ class BackwardsPropagationTest(unittest.TestCase):
         propagation_params = PropagationParams({
             'start_time': start_time_str,
             'end_time': end_time_str,
-            'step_size': 0,
+            'step_size': 86400,
             'project_uuid': self.working_project.get_uuid(),
             'description': 'Created by test at ' + start_time_str
         })


### PR DESCRIPTION
…n running against dev.

This also changes batch.py to explicitly check for None when choosing a step size. Before, step sizes of 0 were getting clobbered. However, since a step size of 0 actually gives somewhat odd results (slight differences between forward and backward propagation, unsure whether that is to be expected), also modifies backwards_propagation_test to explicitly specify 86400 as step size to match former behavior.